### PR TITLE
remove unused module after rename

### DIFF
--- a/protoc-maven-plugin/pom.xml
+++ b/protoc-maven-plugin/pom.xml
@@ -11,12 +11,6 @@
 	<url>https://github.com/blackrock/protoc-jar-maven-plugin</url>
 	<description>Protocol Buffers codegen plugin - based on protoc-jar executable JAR</description>
 
-<!--	<parent>-->
-<!--		<groupId>org.sonatype.oss</groupId>-->
-<!--		<artifactId>oss-parent</artifactId>-->
-<!--		<version>9</version>-->
-<!--	</parent>-->
-
 	<properties>
 		<codehaus.version>3.0</codehaus.version>
 		<grpc.version>1.25.0</grpc.version>
@@ -83,13 +77,6 @@
 			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<!-- JUnit 5 -->
-<!--		<dependency>-->
-<!--			<groupId>org.junit.jupiter</groupId>-->
-<!--			<artifactId>junit-jupiter</artifactId>-->
-<!--			<version>${jupiter.version}</version>-->
-<!--			<scope>test</scope>-->
-<!--		</dependency>-->
 		<dependency>
 			<groupId>io.takari.maven.plugins</groupId>
 			<artifactId>takari-plugin-integration-testing</artifactId>


### PR DESCRIPTION
## Description

maven-plugin module was renamed to protoc-maven-plugin. This left an extraneous unused directory.

## Changes Made

1. removed unused directory
2. deleted a couple of unnecessary, commented out pom content

## Definition of Done

`mvn clean install` works locally on personal machine

## Additional Notes

[Add any additional notes or context for the reviewer or future maintainers of this code.]

Thank you for submitting!