### PR TITLE
Fix maven build warnings

### DIFF
--- a/protoc-jar/pom.xml
+++ b/protoc-jar/pom.xml
@@ -11,6 +11,7 @@
 	<description>Protocol Buffers compiler - executable JAR and API</description>
 
 	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
 		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
 		<maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
@@ -109,7 +110,7 @@
 					<execution>
 						<id>attach-sources</id>
 						<goals>
-							<goal>jar</goal>
+							<goal>jar-no-fork</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/protoc-maven-plugin/pom.xml
+++ b/protoc-maven-plugin/pom.xml
@@ -12,6 +12,7 @@
 	<description>Protocol Buffers codegen plugin - based on protoc-jar executable JAR</description>
 
 	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<codehaus.version>3.0</codehaus.version>
 		<grpc.version>1.25.0</grpc.version>
 		<jupiter.version>5.0.0</jupiter.version>
@@ -156,7 +157,7 @@
 					<execution>
 					<id>attach-sources</id>
 					<goals>
-						<goal>jar</goal>
+						<goal>jar-no-fork</goal>
 					</goals>
 					</execution>
 				</executions>


### PR DESCRIPTION

## Description

Fixes some maven build warnings on source encoding and uses the correct jar-no-fork goal for the attach-sources tasks.

