### PR TITLE
Fix NPE when includeStdTypes flag is set, and clean goal is not specified

### DIFF
--- a/protoc-maven-plugin/src/main/java/io/github/blackrock/protocjar/maven/ProtocJarMojo.java
+++ b/protoc-maven-plugin/src/main/java/io/github/blackrock/protocjar/maven/ProtocJarMojo.java
@@ -346,7 +346,10 @@ public class ProtocJarMojo extends AbstractMojo
 	}
 
 	private void performProtoCompilation(boolean doCodegen) throws MojoExecutionException {
-		if (doCodegen) prepareProtoc();
+		if (doCodegen || includeStdTypes) {
+			// we need the protocVersion initialized if includeStdTypes flag is set
+			prepareProtoc();
+		}
 		
 		// even if doCodegen == false, we still extract extra includes/inputs because addProtoSources might be requested
 		// this could be optimized further

--- a/protoc-maven-plugin/src/test/projects/basic-test/pom.xml
+++ b/protoc-maven-plugin/src/test/projects/basic-test/pom.xml
@@ -56,6 +56,7 @@
 					<configuration>
 						<protocVersion>${protoc.version}</protocVersion>
 						<addProtoSources>all</addProtoSources>
+ 						<includeStdTypes>true</includeStdTypes>
 						<inputDirectories>
 							<include>testprotos</include>
 						</inputDirectories>


### PR DESCRIPTION
## Description

Fixing a NullPointerException when running the goal repeatedly without `clean`.

## Changes Made

The NullPointerException is due to an uninitialized variable for the protocVersion when the plugin detected proto files remain unchanged since last compilation, but the `includeStdTypes` flag is set.

This pull requests adds the includeStdTypes flag check to prevent the NPE.

## Definition of Done

Before submitting this pull request, please ensure that the following criteria have been met:

- [X] All automated tests have passed successfully.
- [X] All manual tests have passed successfully.
- [X] Code has been reviewed by at least one other team member.
- [X] Code has been properly documented and commented as needed.
- [X] All new and existing code adheres to our project's coding standards.
- [X] All dependencies have been added or removed from the project's README or other documentation as needed.
- [X] Any relevant documentation or help files have been updated to reflect the changes made in this pull request.
- [X] Any necessary database migrations have been run.
- [X] Any relevant UI changes have been reviewed and approved by the UI/UX team.
