### PR TITLE
[FEATURE]: toggle skipping project with 'pom' packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,34 @@ Sample usage - compile in test cycle, multiple output targets, don't alter proje
 </plugin>
 ```
 
+Sample usage - generate sources but packaging type of maven project is "pom".
+Requires version greater than 2.0.1.
+
+```xml
+<plugin>
+	<groupId>io.github.blackrock</groupId>
+	<artifactId>protoc-maven-plugin</artifactId>
+	<executions>
+		<execution>
+			<phase>generate-sources</phase>
+			<goals>
+				<goal>run</goal>
+			</goals>
+			<configuration>
+				<protocVersion>2.4.1</protocVersion>
+				<skipPomPackaging>false</skipPomPackaging>
+				<type>python</type>
+				<addSources>none</addSources>
+				<outputDirectory>src/main/python</outputDirectory>
+				<inputDirectories>
+					<include>src/main/protobuf</include>
+				</inputDirectories>
+			</configuration>
+		</execution>
+	</executions>
+</plugin>
+```
+
 ## Contributing
 
 ### [Contributing](./CONTRIBUTING.md)

--- a/protoc-maven-plugin/src/main/java/io/github/blackrock/protocjar/maven/ProtocJarMojo.java
+++ b/protoc-maven-plugin/src/main/java/io/github/blackrock/protocjar/maven/ProtocJarMojo.java
@@ -291,7 +291,7 @@ public class ProtocJarMojo extends AbstractMojo
 	private File tempRoot = null;
 
 	public void execute() throws MojoExecutionException {
-		if (skipPomPackaging && project.getPackaging() != null && "pom".equals(project.getPackaging().toLowerCase())) {
+		if (skipPomPackaging && "pom".equalsIgnoreCase(project.getPackaging())) {
 			getLog().info("Skipping 'pom' packaged project");
 			return;
 		}

--- a/protoc-maven-plugin/src/main/java/io/github/blackrock/protocjar/maven/ProtocJarMojo.java
+++ b/protoc-maven-plugin/src/main/java/io/github/blackrock/protocjar/maven/ProtocJarMojo.java
@@ -259,6 +259,15 @@ public class ProtocJarMojo extends AbstractMojo
 	private String protocArtifact;
 
 	/**
+	* This parameter (when set to false) allows to execute the protoc code generation
+	* when Maven project packaging type is POM. This is required when your packaging type cannot
+	* be one of the standard types like jar, war, ear. This usually happens for non-Java
+	* bindings.
+	*/
+	@Parameter(name="skipPomPackaging", defaultValue = "true")
+	private boolean skipPomPackaging;
+
+	/**
 	 * The Maven project.
 	 */
 	@Parameter(defaultValue = "${project}", required = true, readonly = true)
@@ -282,11 +291,11 @@ public class ProtocJarMojo extends AbstractMojo
 	private File tempRoot = null;
 
 	public void execute() throws MojoExecutionException {
-		if (project.getPackaging() != null && "pom".equals(project.getPackaging().toLowerCase())) {
+		if (skipPomPackaging && project.getPackaging() != null && "pom".equals(project.getPackaging().toLowerCase())) {
 			getLog().info("Skipping 'pom' packaged project");
 			return;
 		}
-		
+
 		if (outputTargets == null || outputTargets.length == 0) {
 			OutputTarget target = new OutputTarget();
 			target.type = type;

--- a/protoc-maven-plugin/src/site/apt/index.apt
+++ b/protoc-maven-plugin/src/site/apt/index.apt
@@ -3,7 +3,7 @@
   Introduction
   ------
 
-protoc-jar-maven-plugin
+protoc-maven-plugin
 
   Protocol Buffers codegen plugin - based on {{{https://github.com/blackrock/protoc-jar}protoc-jar}} executable JAR
 
@@ -27,7 +27,7 @@ protoc-jar-maven-plugin
 +---+
 <plugin>
 	<groupId>io.github.blackrock</groupId>
-	<artifactId>protoc-jar-maven-plugin</artifactId>
+	<artifactId>protoc-maven-plugin</artifactId>
 	<version>1.0.0</version>
 	<executions>
 		<execution>
@@ -46,7 +46,7 @@ protoc-jar-maven-plugin
 +---+
 <plugin>
 	<groupId>io.github.blackrock</groupId>
-	<artifactId>protoc-jar-maven-plugin</artifactId>
+	<artifactId>protoc-maven-plugin</artifactId>
 	<version>1.0.0</version>
 	<executions>
 		<execution>
@@ -75,7 +75,7 @@ protoc-jar-maven-plugin
 +---+
 <plugin>
 	<groupId>io.github.blackrock</groupId>
-	<artifactId>protoc-jar-maven-plugin</artifactId>
+	<artifactId>protoc-maven-plugin</artifactId>
 	<version>1.0.0</version>
 	<executions>
 		<execution>
@@ -109,7 +109,7 @@ protoc-jar-maven-plugin
 +---+
 <plugin>
 	<groupId>io.github.blackrock</groupId>
-	<artifactId>protoc-jar-maven-plugin</artifactId>
+	<artifactId>protoc-maven-plugin</artifactId>
 	<version>1.0.0</version>
 	<executions>
 		<execution>
@@ -143,7 +143,7 @@ protoc-jar-maven-plugin
 +---+
 <plugin>
 	<groupId>io.github.blackrock</groupId>
-	<artifactId>protoc-jar-maven-plugin</artifactId>
+	<artifactId>protoc-maven-plugin</artifactId>
 	<version>1.0.0</version>
 	<executions>
 		<execution>
@@ -170,7 +170,7 @@ protoc-jar-maven-plugin
 +---+
 <plugin>
 	<groupId>io.github.blackrock</groupId>
-	<artifactId>protoc-jar-maven-plugin</artifactId>
+	<artifactId>protoc-maven-plugin</artifactId>
 	<version>1.0.0</version>
 	<executions>
 		<execution>
@@ -197,7 +197,7 @@ protoc-jar-maven-plugin
 +---+
 <plugin>
 	<groupId>io.github.blackrock</groupId>
-	<artifactId>protoc-jar-maven-plugin</artifactId>
+	<artifactId>protoc-maven-plugin</artifactId>
 	<version>1.0.0</version>
 	<executions>
 		<execution>
@@ -225,7 +225,7 @@ protoc-jar-maven-plugin
 +---+
 <plugin>
 	<groupId>io.github.blackrock</groupId>
-	<artifactId>protoc-jar-maven-plugin</artifactId>
+	<artifactId>protoc-maven-plugin</artifactId>
 	<version>1.0.0</version>
 	<executions>
 		<execution>
@@ -262,7 +262,7 @@ protoc-jar-maven-plugin
 +---+
 <plugin>
 	<groupId>io.github.blackrock</groupId>
-	<artifactId>protoc-jar-maven-plugin</artifactId>
+	<artifactId>protoc-maven-plugin</artifactId>
 	<version>1.0.0</version>
 	<executions>
 		<execution>
@@ -275,6 +275,38 @@ protoc-jar-maven-plugin
 				<type>java-shaded</type>
 				<addSources>none</addSources>
 				<outputDirectory>src/main/java</outputDirectory>
+				<inputDirectories>
+					<include>src/main/protobuf</include>
+				</inputDirectories>
+			</configuration>
+		</execution>
+	</executions>
+</plugin>
++---+
+
+  \
+  Sample usage - generate sources but packaging type of maven project is "pom".
+  Requires version greater than 2.0.1.
+
++---+
+<packaging>pom</packaging>
+...
+
+<plugin>
+	<groupId>io.github.blackrock</groupId>
+	<artifactId>protoc-maven-plugin</artifactId>
+	<executions>
+		<execution>
+			<phase>generate-sources</phase>
+			<goals>
+				<goal>run</goal>
+			</goals>
+			<configuration>
+				<protocVersion>2.4.1</protocVersion>
+				<skipPomPackaging>false</skipPomPackaging>
+				<type>python</type>
+				<addSources>none</addSources>
+				<outputDirectory>src/main/python</outputDirectory>
 				<inputDirectories>
 					<include>src/main/protobuf</include>
 				</inputDirectories>

--- a/protoc-maven-plugin/src/test/java/io/github/blackrock/protocjar/maven/NonJavaTest.java
+++ b/protoc-maven-plugin/src/test/java/io/github/blackrock/protocjar/maven/NonJavaTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 protoc-jar developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.blackrock.protocjar.maven;
+
+import io.takari.maven.testing.TestResources;
+import io.takari.maven.testing.executor.MavenRuntime;
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.6.3", "3.8.8", "3.9.6"})
+public class NonJavaTest {
+    @Rule
+    public final TestResources resources = new TestResources();
+    public final MavenRuntime maven;
+
+    public NonJavaTest(MavenRuntimeBuilder mavenBuilder) throws Exception {
+        this.maven = mavenBuilder.withCliOptions("-B", "-U", "-e").build();
+    }
+
+    @Test
+    public void testPyGeneration() throws Exception {
+        File basedir = resources.getBasedir("non-java-test");
+        maven.forProject(basedir)
+            .execute("verify")
+            .assertNoLogText("Skipping 'pom' packaged project")
+            .assertErrorFreeLog();
+        Path genSrc = Paths.get(basedir.getAbsolutePath(), "target", "generated-sources");
+        // The corresponding python binding must be generated.
+        assertTrue("Expected python source file 'PersonSchema_pb2.py' was not generated.", Files.exists(genSrc.resolve("PersonSchema_pb2.py")));
+    }
+}

--- a/protoc-maven-plugin/src/test/projects/non-java-test/pom.xml
+++ b/protoc-maven-plugin/src/test/projects/non-java-test/pom.xml
@@ -1,0 +1,86 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.github.blackrock</groupId>
+    <artifactId>non-java-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>os72</id>
+            <name>Oliver Suciu</name>
+        </developer>
+    </developers>
+
+    <properties>
+        <protobuf.version>3.10.0</protobuf.version>
+        <protoc.version>3.10.0</protoc.version>
+    </properties>
+
+    <dependencies>
+        <!-- compile -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-javalite</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.github.blackrock</groupId>
+                <artifactId>protoc-maven-plugin</artifactId>
+                <version>${it-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.github.blackrock</groupId>
+                        <artifactId>protoc-jar</artifactId>
+                        <version>${it-plugin.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>1</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <protocVersion>${protoc.version}</protocVersion>
+                            <inputDirectories>
+                                <include>testprotos</include>
+                            </inputDirectories>
+                            <skipPomPackaging>false</skipPomPackaging>
+                            <type>python</type>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/protoc-maven-plugin/src/test/projects/non-java-test/testprotos/PersonSchema.proto
+++ b/protoc-maven-plugin/src/test/projects/non-java-test/testprotos/PersonSchema.proto
@@ -1,0 +1,22 @@
+syntax = "proto2";
+option java_package = "io.github.blackrock.test";
+option java_outer_classname = "PersonSchema";
+
+message Person {
+  required int32 id = 1;
+  required string name = 2;
+  optional string email = 3;
+
+  enum PhoneType {
+    MOBILE = 0;
+    HOME = 1;
+    WORK = 2;
+  }
+
+  message PhoneNumber {
+    required string number = 1;
+    optional PhoneType type = 2 [default = HOME];
+  }
+
+  repeated PhoneNumber phone = 4;
+}


### PR DESCRIPTION
## Description

We currently generate bindings for multiple languages. The maven projects are structured in such a way that the packaging type cannot be `jar`, `war` or `ear` for non-java languages.
Since, the updated version of maven install plugin insists on having a packaging type as `pom` for such projects, we feel that this plugin could provide a toggle to allow executing protoc build for such projects.

## Changes Made

- I have added a boolean configuration parameter `skipPomPackaging` to toggle whether the plugin should skip the protoc build execution or not. By default, it is set to true, which preserves the existing behavior.
- I have added a test for this feature.
- I have also updated the documentation content used by maven-site-plugin. The plugin artifactId was incorrect in `index.apt`.

## Definition of Done

Before submitting this pull request, please ensure that the following criteria have been met:

- [ ] All automated tests have passed successfully.
- [x] All manual tests have passed successfully.
- [ ] Code has been reviewed by at least one other team member.
- [ ] Code has been properly documented and commented as needed.
- [ ] All new and existing code adheres to our project's coding standards.
- [ ] All dependencies have been added or removed from the project's README or other documentation as needed.
- [ ] Any relevant documentation or help files have been updated to reflect the changes made in this pull request.
- [ ] Any necessary database migrations have been run.
- [ ] Any relevant UI changes have been reviewed and approved by the UI/UX team.

## Additional Notes

[Add any additional notes or context for the reviewer or future maintainers of this code.]

Thank you for submitting!